### PR TITLE
Create fr_FR.lang

### DIFF
--- a/src/main/resources/assets/cardboardboxes/lang/fr_FR.lang
+++ b/src/main/resources/assets/cardboardboxes/lang/fr_FR.lang
@@ -1,0 +1,6 @@
+tile.cardboardboxes:cardboardbox.name=Boîte
+tile.cardboardboxes:cardboardbox.inventoryFull.name=Votre inventaire semble plein
+tile.cardboardboxes:cardboardbox.banned.block.name=Je ne pense pas pouvoir ramasser ce bloc
+tile.cardboardboxes:cardboardbox.banned.tile.name=Je ne pense pas pouvoir ramasser ce bloc
+tile.cardboardboxes:cardboardbox.noData.name=Ça n'a pas l'air utile de faire ça
+tile.cardboardboxes:cardboardbox.noItem.name=Ça n'a pas l'air de pouvoir être ramassé


### PR DESCRIPTION
There's no satisfactory way of differenciating "block" and "tile" in the commonly seen translations, so I left both messages as the same.